### PR TITLE
removing references to id

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ export default {
 
 # Personas
 A test suite will have a collection of personas to test different scenarios and use cases. Persona data is modeled as parent-child relationships.
-- **id** (string) _required_ - Unique dentifier for the resource
 - **type** (string) _required_ - Resource type, must have a definition with the same name
 - **params** (object) - Request body
 - **children** (array) - An array of children resources which will be seeded after the parent is finished.
@@ -76,7 +75,6 @@ A test suite will have a collection of personas to test different scenarios and 
 ```javascript
 [
   {
-    "id": "user-id",
     "type": "user",
     "params": {
       "username": "Homer_Simpson",
@@ -86,7 +84,6 @@ A test suite will have a collection of personas to test different scenarios and 
     },
     "children": [
       {
-        "id": "client-moe",
         "type": "client",
         "params": {
           "firstName": "Moe",
@@ -100,23 +97,19 @@ A test suite will have a collection of personas to test different scenarios and 
 ```
 
 ### Templates
-As noted above, templates can be used via `childrenTemplate` and `childrenCount` to dynamically generate children resources. The `id` must remain unique, so it's suggested to use a random number or guid (see expression functions below).
+As noted above, templates can be used via `childrenTemplate` and `childrenCount` to dynamically generate children resources.
 ```javascript
 [
   {
-    "id": "user-id",
     "type": "user",
     "childrenCount": "3",
     "childrenTemplate": {
-      "id": "{{guid()}}",
       "type": "client",
       "children": [
         {
-          "id": "{{guid()}}",
           "type": "taxreturn"
         },
         {
-          "id": "{{guid()}}",
           "type": "taxreturn"
         }
       ]

--- a/examples/simple/personas/bart_simpson.json
+++ b/examples/simple/personas/bart_simpson.json
@@ -1,6 +1,5 @@
 [
   {
-    "id": "user",
     "type": "user",
     "params": {
       "firstName": "Bart",
@@ -10,7 +9,6 @@
     },
     "children": [
       {
-        "id": "firm",
         "type": "firm",
         "params": {
           "firmName": "Bart Simpson and Co.",
@@ -19,7 +17,6 @@
         },
         "childrenCount": "3",
         "childrenTemplate": {
-          "id": "client",
           "type": "client",
           "params": {
             "firstName": "{{firstName()}}",
@@ -30,7 +27,6 @@
           },
           "children": [
             {
-              "id": "taxreturn",
               "type": "taxreturn",
               "params": {
                 "type": "1040",
@@ -38,7 +34,6 @@
               }
             },
             {
-              "id": "taxreturn",
               "type": "taxreturn",
               "params": {
                 "type": "1120",

--- a/examples/simple/personas/homer_simpson.json
+++ b/examples/simple/personas/homer_simpson.json
@@ -1,6 +1,5 @@
 [
     {
-        "id": "user",
         "type": "user",
         "params": {
             "firstName": "Homer",
@@ -11,7 +10,6 @@
         "output": "firstName",
         "children": [
             {
-                "id": "firm",
                 "type": "firm",
                 "params": {
                     "firmName": "Homer Simpson and Associates, Inc",
@@ -21,7 +19,6 @@
                 "output": ["firmAddress1", "firmCity", "firm_id"],
                 "children": [
                     {
-                        "id": "client-moe",
                         "type": "client",
                         "params": {
                             "firstName": "Moe",
@@ -32,7 +29,6 @@
                         },
                         "children": [
                             {
-                                "id": "client-moe-return-1",
                                 "type": "taxreturn",
                                 "params": {
                                     "type": "1040",
@@ -43,7 +39,6 @@
                         ]
                     },
                     {
-                        "id": "client-apu",
                         "type": "client",
                         "params": {
                             "firstName": "Apu",
@@ -54,7 +49,6 @@
                         },
                         "children": [
                             {
-                                "id": "client-apu-return-1",
                                 "type": "taxreturn",
                                 "params": {
                                     "type": "1040",
@@ -65,8 +59,7 @@
                         ]
                     },
                     {
-                        "id": "client-snpp",
-                        "type": "client",
+                        "type": "client", 
                         "params": {
                             "organizationName": "Springfield Nuclear Power Plant",
                             "ein": "12-345678",
@@ -75,7 +68,6 @@
                         },
                         "children": [
                             {
-                                "id": "client-snpp-return-1",
                                 "type": "taxreturn",
                                 "params": {
                                     "type": "1120",

--- a/src/expressions.js
+++ b/src/expressions.js
@@ -76,6 +76,5 @@ export default function evaluateExpressions(resource) {
   return {
     ...resource,
     params: recursivelyParsePersonaParams(resource.params),
-    id: conditionallyParseValue(resource.id),
   };
 }

--- a/src/seeder.js
+++ b/src/seeder.js
@@ -61,7 +61,7 @@ class Seeder {
       (resource, definition, resolve, reject) => {
         const data = defaultsDeep(resource.params, definition.body);
 
-        logger.info(`Seeding ${resource.id}`);
+        logger.info(`Seeding ${resource.type}`);
         logger.debug(data);
 
         axios({

--- a/src/templates.js
+++ b/src/templates.js
@@ -11,9 +11,8 @@ function templateProcessor(resource) {
     ? parsed
     : DEFAULT_TEMPLATE_CHILDREN;
 
-  return [...Array(count).keys()].map((i) => {
+  return [...Array(count).keys()].map(() => {
     const template = Object.assign({}, resource.childrenTemplate);
-    template.id = `${template.id}${i}`;
     return template;
   });
 }


### PR DESCRIPTION
ID is currently no longer used due to the enhanced output implemented.

ID later can be added optionally if we expose a util to find the nodes in the response tree based on the id.