### PR TITLE
Temporarily removing winston

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "lodash.defaultsdeep": "^4.6.0",
     "lodash.get": "^4.4.2",
     "lodash.set": "^4.3.2",
-    "winston": "^2.4.1",
     "babel-runtime": "^6.26.0"
   },
   "devDependencies": {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,82 +1,23 @@
-import winston from 'winston';
 
 /**
  * A logger utility.
  * @class
  */
 class Logger {
-  constructor() {
-    /**
-         * The default logging configuration.
-         * @type {Object}
-         * @access private
-         */
-    this._defaultConfig = {
-      levels: {
-        verbose: 1,
-        debug: 2,
-        info: 3,
-        warn: 4,
-        error: 5,
-      },
-      colors: {
-        verbose: 'grey',
-        debug: 'white',
-        info: 'cyan',
-        warn: 'yellow',
-        error: 'red',
-      },
-    };
-
-    /**
-         * The default console transport.
-         * @type {Object}
-         * @access private
-         */
-    this._consoleTransport = new winston.transports.Console({
-      timestamp: true,
-      json: false,
-      colorize: true,
-      handleExceptions: true,
-      level: 'warn',
-    });
-
-    /**
-         * The logger instance.
-         * @type {Object}
-         * @access private
-         */
-    this._logger = new winston.Logger({
-      transports: [this._consoleTransport],
-      levels: this._defaultConfig.levels,
-      colors: this._defaultConfig.colors,
-    });
-  }
-
   /**
      * A way to set a custom logging level.
-     * @param {string} level The logging level to set (debug, info, error, etc).
      * @access public
      */
-  setLoggingLevel(level) {
-    this._logger.configure({
-      level,
-      transports: [this._consoleTransport],
-    });
+  setLoggingLevel() {
+    this.warn('Setting logging level is currently disabled.');
   }
 
   /**
      * Enable logging to file.
-     * @param {string} filename
      * @access public
      */
-  logToFile(filename) {
-    this._logger.configure({
-      transports: [
-        this._consoleTransport,
-        new winston.transports.File({ filename }),
-      ],
-    });
+  logToFile() {
+    this.warn('Logging to file is currently disabled.');
   }
 
   /**
@@ -122,7 +63,14 @@ class Logger {
      * @access private
      */
   _log(level, msg) {
-    this._logger.log(level, msg);
+    let output = msg;
+
+    if (typeof output === 'object') {
+      output = JSON.stringify(output);
+    }
+
+    output = `${new Date().toUTCString()} ${level}: ${output}`;
+    console[level].call(this, output); // eslint-disable-line no-console
   }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -521,10 +521,6 @@ async@^2.6.0:
   dependencies:
     lodash "^4.14.0"
 
-async@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/async/-/async-1.0.0.tgz#f8fc04ca3a13784ade9e1641af98578cfbd647a9"
-
 atob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/atob/-/atob-2.1.1.tgz#ae2d5a729477f289d60dd7f96a6314a22dd6c22a"
@@ -1904,7 +1900,7 @@ color-name@^1.1.1:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.3.tgz#a7d0558bd89c42f795dd42328f740831ca53bc25"
 
-colors@1.0.3, colors@1.0.x:
+colors@1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/colors/-/colors-1.0.3.tgz#0433f44d809680fdeb60ed260f1b0c262e82a40b"
 
@@ -2148,10 +2144,6 @@ currently-unhandled@^0.4.1:
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
   dependencies:
     array-find-index "^1.0.1"
-
-cycle@1.0.x:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/cycle/-/cycle-1.0.3.tgz#21e80b2be8580f98b468f379430662b046c34ad2"
 
 cyclist@~0.2.2:
   version "0.2.2"
@@ -2731,10 +2723,6 @@ extsprintf@1.2.0:
 extsprintf@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
-
-eyes@0.1.x:
-  version "0.1.8"
-  resolved "https://registry.yarnpkg.com/eyes/-/eyes-0.1.8.tgz#62cf120234c683785d902348a800ef3e0cc20bc0"
 
 fast-deep-equal@^1.0.0:
   version "1.1.0"
@@ -3824,10 +3812,6 @@ isobject@^2.0.0:
 isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
-
-isstream@0.1.x:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
 
 istanbul-lib-coverage@^1.1.0, istanbul-lib-coverage@^1.1.2, istanbul-lib-coverage@^1.2.0:
   version "1.2.0"
@@ -6087,10 +6071,6 @@ ssri@^5.2.4:
   dependencies:
     safe-buffer "^5.1.1"
 
-stack-trace@0.0.x:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stack-trace/-/stack-trace-0.0.10.tgz#547c70b347e8d32b4e108ea1a2a159e5fdde19c0"
-
 stack-utils@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.1.tgz#d4f33ab54e8e38778b0ca5cfd3b3afb12db68620"
@@ -6821,17 +6801,6 @@ widest-line@^2.0.0:
 window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
-
-winston@^2.4.1:
-  version "2.4.2"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.2.tgz#3ca01f763116fc48db61053b7544e750431f8db0"
-  dependencies:
-    async "~1.0.0"
-    colors "1.0.x"
-    cycle "1.0.x"
-    eyes "0.1.x"
-    isstream "0.1.x"
-    stack-trace "0.0.x"
 
 wordwrap@0.0.2:
   version "0.0.2"


### PR DESCRIPTION
Winston doesn't work in the browser until 3.1.0, which isn't released. As a temporary stop-gap, we're removing it in favor of simple console.logs.