### PR TITLE
Adding support for timestamps in email addresses

### DIFF
--- a/src/__tests__/expressionFunctions.js
+++ b/src/__tests__/expressionFunctions.js
@@ -54,8 +54,7 @@ test('email', (t) => {
   t.true(expFns.email().indexOf('@') !== -1);
   t.true(expFns.email().indexOf('.') !== -1);
   t.true(expFns.email('intuit.com').indexOf('@intuit.com') !== -1);
-  t.true(expFns.email('intuit.com', true).indexOf('_') !== -1);
-  t.true(expFns.email('intuit.com', true).indexOf('@intuit.com') !== -1);
+  t.truthy(expFns.email('intuit.com', true).match(/^[a-zA-Z]+_+[0-9]+@intuit.com/));
 });
 
 test('gender', (t) => {

--- a/src/__tests__/expressionFunctions.js
+++ b/src/__tests__/expressionFunctions.js
@@ -53,7 +53,9 @@ test('ein', (t) => {
 test('email', (t) => {
   t.true(expFns.email().indexOf('@') !== -1);
   t.true(expFns.email().indexOf('.') !== -1);
-  t.true(expFns.email('intuit.com').indexOf('intuit.com') !== -1);
+  t.true(expFns.email('intuit.com').indexOf('@intuit.com') !== -1);
+  t.true(expFns.email('intuit.com', true).indexOf('_') !== -1);
+  t.true(expFns.email('intuit.com', true).indexOf('@intuit.com') !== -1);
 });
 
 test('gender', (t) => {

--- a/src/expressionFunctions.js
+++ b/src/expressionFunctions.js
@@ -53,11 +53,9 @@ function ein() {
 function email(domain = null, timestamp = false) {
   let email = chance.email({ domain });
   if (timestamp === true) {
-    const i = email.indexOf('@');
     const split = email.split('');
-    split.splice(i, 0, '_', Date.now());
+    split.splice(email.indexOf('@'), 0, '_', Date.now());
     email = split.join('');
-    console.log(email);
   }
   return email;
 }

--- a/src/expressionFunctions.js
+++ b/src/expressionFunctions.js
@@ -53,9 +53,7 @@ function ein() {
 function email(domain = null, timestamp = false) {
   let email = chance.email({ domain });
   if (timestamp === true) {
-    const split = email.split('');
-    split.splice(email.indexOf('@'), 0, '_', Date.now());
-    email = split.join('');
+    email = email.replace('@', `_${Date.now()}@`);
   }
   return email;
 }

--- a/src/expressionFunctions.js
+++ b/src/expressionFunctions.js
@@ -50,8 +50,16 @@ function ein() {
   }).join('');
 }
 
-function email(domain = null) {
-  return chance.email({ domain });
+function email(domain = null, timestamp = false) {
+  let email = chance.email({ domain });
+  if (timestamp === true) {
+    const i = email.indexOf('@');
+    const split = email.split('');
+    split.splice(i, 0, '_', Date.now());
+    email = split.join('');
+    console.log(email);
+  }
+  return email;
 }
 
 function gender() {


### PR DESCRIPTION
Chance.js' randomly generated emails aren't very unique. This adds support for an additional expression function argument that appends a timestamp to the email address:

```javascript
// From
jo@intuit.com

// To ({{email('intuit.com', true}})
jo_1539894592696@intuit.com
```