### PR TITLE
console check to work with cypress plugins

### DIFF
--- a/src/logger.js
+++ b/src/logger.js
@@ -63,6 +63,10 @@ class Logger {
      * @access private
      */
   _log(level, msg) {
+    if (!console[level]) { // eslint-disable-line no-console
+      return;
+    }
+
     let output = msg;
 
     if (typeof output === 'object') {


### PR DESCRIPTION
Cypress doesn't expose the same `console` methods in their plugins, this is a workaround.